### PR TITLE
Add choco v2 module import to support call of refreshenv

### DIFF
--- a/windows-2019/Dockerfile
+++ b/windows-2019/Dockerfile
@@ -16,4 +16,5 @@ RUN $old = (Get-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentC
     $new = $old + $flywayPath; `
     Write-Host $new; `
     Set-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name path -Value $new; `
+    Import-Module $env:ChocolateyInstall\helpers\chocolateyProfile.psm1; `
     refreshenv


### PR DESCRIPTION
The latest version of `octopuslabs/worker-tools` for windows is now based off of the `mcr.microsoft.com/dotnet/framework/runtime:4.8-windowsservercore-ltsc2019` image (instead of `mcr.microsoft.com/windows/servercore:ltsc2019`). This is due to the use of chocolatey to install various tools on the image.

V2 of chocolatey which has just been released now requires .NET 4.8 which the change above supports. See [this](https://docs.chocolatey.org/en-us/guides/upgrading-to-chocolatey-v2-v6#net-framework-4.8-required) for more info.

This PR addresses the required changes in this repo for the windows image. Namely importing the chocolatey profile before `refreshenv` is called.